### PR TITLE
Correct setFirefoxProfile example

### DIFF
--- a/howtos/setFirefoxProfile/helper.js
+++ b/howtos/setFirefoxProfile/helper.js
@@ -8,8 +8,10 @@ exports.getFirefoxProfile = function() {
   firefoxProfile.setPreference('browser.newtab.url', 'https://www.angularjs.org');
   firefoxProfile.encoded(function(encodedProfile) {
     var multiCapabilities = [{
-      browserName: 'firefox',
-      firefox_profile : encodedProfile
+      'browserName': 'firefox',
+      'moz:firefoxOptions': {
+         profile: encodedProfile
+      }
     }];
     deferred.resolve(multiCapabilities);
   });


### PR DESCRIPTION
Fixed the example by setting `.moz:firefoxOptions.profile` instead of `.profile`. Also see the [Geckodriver docs](https://firefox-source-docs.mozilla.org/testing/geckodriver/geckodriver/Capabilities.html).