### PR TITLE
Updated setFirefoxProfile example

### DIFF
--- a/howtos/setFirefoxProfile/README.md
+++ b/howtos/setFirefoxProfile/README.md
@@ -5,5 +5,5 @@ To run:
 
 `protractor howtos/setFirefoxProfile/conf.js`
 
-Once you do that, firefox will wait for 10 seconds, during these 10 seconds
-  you can open a new tab to verify that the firefox profile has been changed.
+Once you do that, firefox will wait for 60 seconds, during these 60 seconds
+  you can open the homepage to verify that the firefox profile has been changed.

--- a/howtos/setFirefoxProfile/helper.js
+++ b/howtos/setFirefoxProfile/helper.js
@@ -6,14 +6,14 @@ exports.getFirefoxProfile = function () {
 
     const firefoxProfile = new FirefoxProfile();
     firefoxProfile.setPreference('browser.startup.homepage', 'https://www.protractortest.org/#/');
-    firefoxProfile.encoded(function (encodedProfile) {
+    firefoxProfile.encoded(function (error, encodedProfile) {
         const multiCapabilities = [{
             'browserName': 'firefox',
             'moz:firefoxOptions': {
                 'profile': encodedProfile
             }
         }];
-        deferred.resolve(multiCapabilities);
+        error ? deferred.reject(error) : deferred.resolve(multiCapabilities);
     });
 
     return deferred.promise;

--- a/howtos/setFirefoxProfile/helper.js
+++ b/howtos/setFirefoxProfile/helper.js
@@ -1,18 +1,20 @@
-var q = require('q');
-var FirefoxProfile = require('firefox-profile');
+const q = require('q');
+const FirefoxProfile = require('firefox-profile');
 
-exports.getFirefoxProfile = function() {
-  var deferred = q.defer();
+exports.getFirefoxProfile = function () {
+    const deferred = q.defer();
 
-  var firefoxProfile = new FirefoxProfile();
-  firefoxProfile.setPreference('browser.newtab.url', 'https://www.angularjs.org');
-  firefoxProfile.encoded(function(encodedProfile) {
-    var multiCapabilities = [{
-      browserName: 'firefox',
-      firefox_profile : encodedProfile
-    }];
-    deferred.resolve(multiCapabilities);
-  });
+    const firefoxProfile = new FirefoxProfile();
+    firefoxProfile.setPreference('browser.startup.homepage', 'https://www.protractortest.org/#/');
+    firefoxProfile.encoded(function (encodedProfile) {
+        const multiCapabilities = [{
+            'browserName': 'firefox',
+            'moz:firefoxOptions': {
+                'profile': encodedProfile
+            }
+        }];
+        deferred.resolve(multiCapabilities);
+    });
 
-  return deferred.promise;
+    return deferred.promise;
 };

--- a/howtos/setFirefoxProfile/spec.js
+++ b/howtos/setFirefoxProfile/spec.js
@@ -1,8 +1,7 @@
 describe('setting firefox profile', function() {
   it ('newtab.url is changed', function() {
-    browser.sleep(10000);
+    browser.sleep(60000);
 
-    //if you open a new tab now, you should see that the new tab goes to
-    //  angularjs.org instead of the default
+    // if click the home button you should see that it goes to the Protractor website, instead of the default
   })
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "protractor": "2.1.0",
     "mkdirp": "~0.3.5",
     "q": "1.0.0",
-    "firefox-profile": "0.3.4"
+    "firefox-profile": "1.2.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Fixed the example by setting `.moz:firefoxOptions.profile` instead of `.profile`. Also see the [Geckodriver docs](https://firefox-source-docs.mozilla.org/testing/geckodriver/geckodriver/Capabilities.html).